### PR TITLE
Replace `which` with `type`

### DIFF
--- a/mcfly
+++ b/mcfly
@@ -36,7 +36,7 @@ version=$(curl -s "$api/api/v1/info" | yq r - "version")
 
 fly="fly-$version"
 
-if ! which -s "$fly" ; then 
+if ! type "$fly" > /dev/null; then
   platform=$(uname | tr '[[:upper:]]' '[[:lower:]]')
   arch=$(get_arch)
   read -p "Downloading $fly from $api: Press Enter to continue, ^C to cancel "


### PR DESCRIPTION
On Debian bullseye, `which` does not have a `-s` option and the command
`which` is not available in all environments. This commit use a shell
builin instead and pipes stdout to /dev/null.

Authored-by: Bradford D. Boyle <bboyle@pivotal.io>